### PR TITLE
Added CNAME to not show redirect

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-buckhacks.org
+www.buckhacks.org

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+buckhacks.org


### PR DESCRIPTION
If you want to update the DNS to have 'www.buckhacks.org' be a `CNAME` record for this GitHub pages site, this file will allow that domain name to persist and not become 'buckeyehackers.github.io'.

Reference: https://help.github.com/articles/setting-up-a-custom-domain-with-github-pages/
